### PR TITLE
Template: Show main sections inline

### DIFF
--- a/template-ui/src/components/SectionContent.vue
+++ b/template-ui/src/components/SectionContent.vue
@@ -1,0 +1,38 @@
+<template>
+  <span>
+    <SectionTitle :section="section" />
+
+    <CardGrid
+      v-for="child in section.children"
+      :key="child.id"
+      :nodes="child.children"
+      :id="child.id"
+      v-if="inlineSection"
+    >
+      <b-row>
+        <SectionTitle tag="h4" :section="child" :showDescription="true" />
+      </b-row>
+    </CardGrid>
+
+    <CardGrid
+      :nodes="section.children"
+      :id="section.id"
+      v-if="!inlineSection"
+    />
+  </span>
+</template>
+
+<script>
+
+export default {
+  name: 'SectionContent',
+  props: {
+    section: Object,
+  },
+  computed: {
+    inlineSection() {
+      return this.section.children.every((s) => s.kind === 'topic');
+    },
+  },
+};
+</script>

--- a/template-ui/src/components/SectionTitle.vue
+++ b/template-ui/src/components/SectionTitle.vue
@@ -1,8 +1,21 @@
 <template>
 <b-container>
-  <h3 :id="sectionSlug">
+  <component :is="tag" :id="sectionSlug">
     <span class="title" >{{ section.title }}</span>
-  </h3>
+    <b-button
+      v-b-toggle="'collapse-description-' + section.id"
+      variant="link"
+      v-if="showDescription && section.description"
+    >
+      <b-icon-info-circle />
+    </b-button>
+  </component>
+  <b-collapse
+    :id="'collapse-description-' + section.id"
+    v-if="showDescription && section.description"
+  >
+    {{ section.description }}
+  </b-collapse>
 </b-container>
 </template>
 
@@ -13,6 +26,14 @@ export default {
   name: 'SectionTitle',
   props: {
     section: Object,
+    showDescription: {
+      type: Boolean,
+      default: false,
+    },
+    tag: {
+      type: String,
+      default: 'h3',
+    },
   },
   computed: {
     sectionSlug() {

--- a/template-ui/src/views/Home.vue
+++ b/template-ui/src/views/Home.vue
@@ -7,16 +7,11 @@
       v-if="contentNodes"
     />
 
-    <CardGrid
+    <SectionContent
       v-for="section in mainSections"
       :key="section.id"
-      :nodes="section.children"
-      :id="section.id"
-    >
-      <b-row>
-        <SectionTitle :section="section" />
-      </b-row>
-    </CardGrid>
+      :section="section"
+    />
 
   </div>
 </template>


### PR DESCRIPTION
This patch adds a new component to show main sections, if a section is
just a folder, this new component shows each section inside so a level
is removed from the navigation tree.

https://phabricator.endlessm.com/T31416