### PR TITLE
pbskids: Make compatible with IE11

### DIFF
--- a/pbskids-ui/vue.config.js
+++ b/pbskids-ui/vue.config.js
@@ -1,3 +1,16 @@
 module.exports = {
   publicPath: './',
+  transpileDependencies: [
+    '@pixi/app',
+    '@pixi/constants',
+    '@pixi/core',
+    '@pixi/display',
+    '@pixi/filter-displacement',
+    '@pixi/loaders',
+    '@pixi/prepare',
+    '@pixi/sprite',
+    '@pixi/spritesheet',
+    '@pixi/ticker',
+    '@pixi/math',
+  ],
 };


### PR DESCRIPTION
This patch adds the pixi dependencies to the transpileDependencies so it
works on IE11.

https://phabricator.endlessm.com/T31420