### PR TITLE
Template: Paginate prop in CardGrid

### DIFF
--- a/template-ui/src/components/CardGrid.vue
+++ b/template-ui/src/components/CardGrid.vue
@@ -1,38 +1,13 @@
 <template>
   <b-container class="section-container my-5">
     <slot></slot>
-    <b-row>
-      <b-col
-        cols="6"
-        md="4"
-        class="subsection"
-        v-for="node in nodes.slice(0, 6)"
-        :key="node.id"
-      >
-        <Card :node="node" />
-      </b-col>
-    </b-row>
-    <b-collapse :id="'collapse-' + id" class="mt-2">
-      <b-row>
-        <b-col
-          cols="6"
-          md="4"
-          class="subsection"
-          v-for="node in nodes.slice(6)"
-          :key="'item-' + node.id"
-        >
-          <Card :node="node" />
-        </b-col>
-      </b-row>
-    </b-collapse>
-    <b-row align-h="center" v-if="nodes.length > 6">
-      <b-button class="mt-2" v-b-toggle="'collapse-' + id" variant="light">
-        <span class="when-open">Show less</span>
-        <span class="when-closed">Show more</span>
-        <b-icon-arrow-up class="when-open" />
-        <b-icon-arrow-down class="when-closed" />
-      </b-button>
-    </b-row>
+
+    <component
+      :is="displayVariant"
+      :nodes="nodes"
+      :id="id"
+      :itemsPerPage="itemsPerPage"
+    />
   </b-container>
 </template>
 
@@ -40,21 +15,31 @@
 
 export default {
   name: 'CardGrid',
-  props: ['nodes', 'id'],
-  computed: {},
+  props: {
+    nodes: Array,
+    id: String,
+    variant: {
+      type: String,
+      default: 'collapsible',
+      validator(value) {
+        // The value must match one of these strings
+        return ['paginated', 'collapsible'].includes(value);
+      },
+    },
+    itemsPerPage: {
+      type: Number,
+      default: 6,
+    },
+  },
+  computed: {
+    displayVariant() {
+      switch (this.variant) {
+        case 'paginated':
+          return 'PaginatedCardGrid';
+        default:
+          return 'CollapsibleCardGrid';
+      }
+    },
+  },
 };
 </script>
-
-<style lang="scss" scoped>
-@import "@/styles.scss";
-
-.collapsed > .when-open,
-.not-collapsed > .when-closed {
-  display: none;
-}
-
-button:hover {
-  color: $primary !important;
-}
-
-</style>

--- a/template-ui/src/components/CollapsibleCardGrid.vue
+++ b/template-ui/src/components/CollapsibleCardGrid.vue
@@ -1,0 +1,48 @@
+<template>
+  <span>
+    <GridPage :nodes="nodes.slice(0, itemsPerPage)" />
+
+    <b-collapse :id="'collapse-' + id" class="mt-2">
+      <GridPage :nodes="nodes.slice(itemsPerPage)" />
+    </b-collapse>
+
+    <b-row align-h="center" v-if="nodes.length > itemsPerPage">
+      <b-button class="mt-2" v-b-toggle="'collapse-' + id" variant="light">
+        <span class="when-open">Show less</span>
+        <span class="when-closed">Show more</span>
+        <b-icon-arrow-up class="when-open" />
+        <b-icon-arrow-down class="when-closed" />
+      </b-button>
+    </b-row>
+  </span>
+</template>
+
+<script>
+
+export default {
+  name: 'CollapsibleCardGrid',
+  props: {
+    nodes: Array,
+    id: String,
+    itemsPerPage: {
+      type: Number,
+      default: 6,
+    },
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+
+@import "@/styles.scss";
+
+.collapsed > .when-open,
+.not-collapsed > .when-closed {
+  display: none;
+}
+
+button:hover {
+  color: $primary !important;
+}
+
+</style>

--- a/template-ui/src/components/GridPage.vue
+++ b/template-ui/src/components/GridPage.vue
@@ -1,0 +1,21 @@
+<template>
+  <b-row>
+    <b-col
+      cols="6"
+      md="4"
+      class="subsection"
+      v-for="node in nodes"
+      :key="node.id"
+    >
+      <Card :node="node" />
+    </b-col>
+  </b-row>
+</template>
+
+<script>
+
+export default {
+  name: 'GridPage',
+  props: ['nodes'],
+};
+</script>

--- a/template-ui/src/components/PaginatedCardGrid.vue
+++ b/template-ui/src/components/PaginatedCardGrid.vue
@@ -1,0 +1,45 @@
+<template>
+  <span>
+    <GridPage :nodes="pageNodes" />
+
+    <b-pagination
+      v-if="nodes.length > itemsPerPage"
+      v-model="currentPage"
+      :total-rows="nodes.length"
+      :per-page="itemsPerPage"
+      align="center"
+    />
+  </span>
+</template>
+
+<script>
+
+export default {
+  name: 'PaginatedCardGrid',
+  props: {
+    nodes: Array,
+    id: String,
+    itemsPerPage: {
+      type: Number,
+      default: 6,
+    },
+  },
+  data() {
+    return {
+      currentPage: 1,
+    };
+  },
+  computed: {
+    pages() {
+      const n = Math.ceil(this.nodes.length / this.itemsPerPage);
+      return [...Array(n).keys()];
+    },
+    pageNodes() {
+      const { currentPage, itemsPerPage, nodes } = this;
+      const start = (currentPage - 1) * itemsPerPage;
+      const end = start + itemsPerPage;
+      return nodes.slice(start, end);
+    },
+  },
+};
+</script>

--- a/template-ui/src/views/Section.vue
+++ b/template-ui/src/views/Section.vue
@@ -12,6 +12,8 @@
     :key="section.id"
     :nodes="section.children"
     :id="section.id"
+    variant="paginated"
+    :itemsPerPage="6"
   />
   </div>
 </template>


### PR DESCRIPTION
Adds a paginate property to the CardGrid component to choose between
paginated or the previous version with a show more button.  The
pagination can be configured also with the itemsPerPage property.

This patch slo moves some code to a new component called GridPage, to
remove code duplication.

https://phabricator.endlessm.com/T31511