### PR TITLE
channel: Fix sikana sport section icon

### DIFF
--- a/template-ui/channel-overrides/sikana/components/SectionTitle.vue
+++ b/template-ui/channel-overrides/sikana/components/SectionTitle.vue
@@ -64,7 +64,7 @@ export default {
     &.si-health::before {
       content: "\29";
     }
-    &.si-sports::before {
+    &.si-sport::before {
       content: "\5f";
     }
   }


### PR DESCRIPTION
The sport icon class didn't match the section title. This fixes that
issue.

https://phabricator.endlessm.com/T31605