### PR TITLE
template: Allow overriding asset filenames

### DIFF
--- a/docs/template-spec.md
+++ b/docs/template-spec.md
@@ -37,10 +37,10 @@ The next level of customization is adding background images:
 The default card image is the thumbnail that will be used when the
 content doesn't have any thumbnail attached to it in Kolibri Studio.
 
-**Note:** At the moment the image format is more constrained than this
-spec shows, so your provided assets could be converted. Please refer
-to the [template technical information](./template-tech-info.md) for
-details.
+**Note:** There is a default file name and format for each image
+asset. Please refer to the [template technical
+information](./template-tech-info.md) for details on how to change
+these defaults.
 
 ### Overriding components
 
@@ -63,8 +63,8 @@ Soon you will be able to pass more options to the template to change
 the navigation in different ways like: pagination, collapsible cards,
 number of columns in the card grid.
 
-Also for appifying the channel on Endless OS, you will need at least a
-desktop icon.
+For app-ifying the channel on Endless OS, the channel thumbnail will
+be used to create the desktop icon.
 
 ## Exclusive to the Kolibri Explore mid-term solution
 

--- a/docs/template-tech-info.md
+++ b/docs/template-tech-info.md
@@ -8,20 +8,59 @@ The override is no more than a symlink pointing to your directory from
 `scripts/set_override.py` and `scripts/clear_override.py` to do it
 safely. Check the `--help` of each command for details.
 
+## Overriding
+
+### CSS
+
 Custom CSS goes to your `styles.scss`. In particular, Bootstrap
 variables can be set, like: `$primary: #42b983;`. See the
 `default/styles.scss` for reference.
 
+### Image assets
+
 Image assets can be added to your override in a `assets/`
-subdirectory. Right now the file names (and thus format because of the
-way Webpack bundling works) have to match exactly. Use the following
-command to find all the current asset overrides available:
+subdirectory. See the `assetFilenames` Vuex store object for the
+mapping of asset name -> default file name.
+
+These file names also enforce a file format (because of the way
+Webpack loaders work) but the good news is that you can override the
+mapping and change any file name. See **Custom store state** below.
+
+### Custom store state
+
+You can override the initial Vuex store state if you add an
+`options.json` file in your directory override. Here is an example for
+customizing the asset filenames:
 
 ```
-git grep dynamicRequireAsset\(
+{
+  "assetFilenames": {
+    "defaultThumbnail": "custom.png",
+    "homeBackgroundImage": "custom.png",
+    "sectionBackgroundImage": "custom.png",
+    "footerImage": "custom.png"
+  }
+}
 ```
+
+### Components
 
 Vue components can be added to your override in a `components/`
 subdirectory. They will replace any component in `src/components/` if
 they have the same file name. You can start by copying one component
 and doing slight modifications.
+
+## Example override directory structure
+
+```
+.
+ \_ styles.scss
+ \_ options.json
+ \_ assets/
+           \_ footer-background.jpg
+           \_ custom-asset.svg
+ |
+ \_ components/
+               \_ HeaderNavBarBrand.vue
+               \_ SectionTitle.vue
+```

--- a/template-ui/src/components/Card.vue
+++ b/template-ui/src/components/Card.vue
@@ -28,9 +28,6 @@
 <script>
 import { getThumbnail, goToContent } from 'kolibri-api';
 import { mapGetters } from 'vuex';
-import dynamicRequireAsset from '@/dynamicRequireAsset';
-
-const defaultThumbnail = dynamicRequireAsset('default-card-thumbnail.svg');
 
 export default {
   props: ['node'],
@@ -40,7 +37,7 @@ export default {
     };
   },
   computed: {
-    ...mapGetters(['getCardLabel']),
+    ...mapGetters(['getCardLabel', 'getAsset']),
     title() {
       if (this.node.kind === 'topic') {
         return this.getCardLabel(this.node);
@@ -58,7 +55,7 @@ export default {
     },
     async getThumbnail() {
       if (!this.node.thumbnail && process.env.VUE_APP_USE_MOCK_DATA === 'true') {
-        this.thumbnail = defaultThumbnail;
+        this.thumbnail = this.getAsset('defaultThumbnail');
         return;
       }
       if (this.node.thumbnail) {
@@ -69,7 +66,7 @@ export default {
       if (thumbnail) {
         this.thumbnail = thumbnail;
       } else {
-        this.thumbnail = defaultThumbnail;
+        this.thumbnail = this.getAsset('defaultThumbnail');
       }
     },
   },

--- a/template-ui/src/components/Footer.vue
+++ b/template-ui/src/components/Footer.vue
@@ -14,20 +14,16 @@
 </template>
 
 <script>
-import { mapState } from 'vuex';
-import dynamicRequireAsset from '@/dynamicRequireAsset';
-
-const footerImage = dynamicRequireAsset('footer-background.jpg');
+import { mapState, mapGetters } from 'vuex';
 
 export default {
   name: 'Footer',
-  data() {
-    return {
-      footerImageURL: footerImage ? `url(${footerImage})` : null,
-    };
-  },
   computed: {
     ...mapState(['channel']),
+    ...mapGetters(['getAssetURL']),
+    footerImageURL() {
+      return this.getAssetURL('footerImage');
+    },
   },
 };
 </script>

--- a/template-ui/src/store/index.js
+++ b/template-ui/src/store/index.js
@@ -1,6 +1,7 @@
 import Vue from 'vue';
 import Vuex from 'vuex';
 import { getNodesTree } from '@/utils';
+import dynamicRequireAsset from '@/dynamicRequireAsset';
 
 let storeData;
 try {
@@ -39,6 +40,14 @@ const initialState = {
   // Navigation state:
   section: {},
   parentSection: {},
+
+  // Asset filenames that can be overriden:
+  assetFilenames: {
+    defaultThumbnail: 'default-card-thumbnail.svg',
+    homeBackgroundImage: 'home-background.jpg',
+    sectionBackgroundImage: 'section-background.jpg',
+    footerImage: 'footer-background.jpg',
+  },
 };
 
 const store = new Vuex.Store({
@@ -75,6 +84,11 @@ const store = new Vuex.Store({
         kindsLabel = labelPerKind[kind] || defaultKindLabel;
       }
       return `${node.title} - ${leaves.length} ${kindsLabel}`;
+    },
+    getAsset: (state) => (name) => dynamicRequireAsset(state.assetFilenames[name]),
+    getAssetURL: (_, getters) => (name) => {
+      const asset = getters.getAsset(name);
+      return asset ? `url(${asset})` : null;
     },
     isInlineLevel: (state) => state.section.children.every((n) => n.kind === 'topic'),
   },

--- a/template-ui/src/views/Home.vue
+++ b/template-ui/src/views/Home.vue
@@ -26,20 +26,15 @@
 
 <script>
 import { mapState, mapGetters } from 'vuex';
-import dynamicRequireAsset from '@/dynamicRequireAsset';
-
-const backgroundImage = dynamicRequireAsset('home-background.jpg');
 
 export default {
   name: 'Home',
-  data() {
-    return {
-      backgroundImageURL: backgroundImage ? `url(${backgroundImage})` : null,
-    };
-  },
   computed: {
     ...mapState(['channel', 'nodes', 'section']),
-    ...mapGetters(['mainSections']),
+    ...mapGetters(['mainSections', 'getAssetURL']),
+    backgroundImageURL() {
+      return this.getAssetURL('homeBackgroundImage');
+    },
     contentNodes() {
       if (!this.section || !this.section.children) {
         return null;

--- a/template-ui/src/views/Section.vue
+++ b/template-ui/src/views/Section.vue
@@ -35,20 +35,15 @@
 <script>
 import { mapState, mapGetters } from 'vuex';
 import { goToContent } from 'kolibri-api';
-import dynamicRequireAsset from '@/dynamicRequireAsset';
-
-const backgroundImage = dynamicRequireAsset('section-background.jpg');
 
 export default {
   name: 'Section',
-  data() {
-    return {
-      backgroundImageURL: backgroundImage ? `url(${backgroundImage})` : null,
-    };
-  },
   computed: {
     ...mapState(['section', 'parentSection']),
-    ...mapGetters(['isInlineLevel']),
+    ...mapGetters(['isInlineLevel', 'getAssetURL']),
+    backgroundImageURL() {
+      return this.getAssetURL('sectionBackgroundImage');
+    },
   },
   methods: {
     goToContent,


### PR DESCRIPTION
State:

- Add a new `assetFilenames` object to the state to map names to
filenames. This can be overriden with the `options.json` state
override.

- Add getters `getAsset()` and `getAssetURL()` to dynamically
require the assets in the components.

Views and components:

- Adapt them all to use the getters.

https://phabricator.endlessm.com/T31512