### PR TITLE
template: Custom CarouselCard style

### DIFF
--- a/template-ui/src/components/Carousel.vue
+++ b/template-ui/src/components/Carousel.vue
@@ -3,8 +3,7 @@
   <b-carousel
     v-model="slide"
     :interval="4000"
-    img-width="1024"
-    img-height="380"
+    class="shadow-lg"
   >
     <CarouselCard
       v-for="node in carouselNodes"
@@ -57,5 +56,8 @@ export default {
 
 .carousel-item {
   background: $secondary !important;
+}
+.carousel {
+  border-radius: $border-radius-lg;
 }
 </style>

--- a/template-ui/src/components/CarouselCard.vue
+++ b/template-ui/src/components/CarouselCard.vue
@@ -1,25 +1,83 @@
 <template>
   <ContentLink :node="node">
-    <b-carousel-slide
-      :caption="section.title"
-      :text="node.title"
-      :img-src="thumbnail"
-    />
+    <b-carousel-slide>
+      <template #img>
+        <b-card :title="node.title">
+          <template>
+            <div class="img" :style="backgroundStyle"></div>
+            <b-card-text>
+              <p>by {{ node.author || node.license_owner }}</p>
+              <p class="text-muted">
+                <v-clamp
+                  autoresize
+                  :max-lines="5"
+                >
+                  {{ node.description }}
+                </v-clamp>
+              </p>
+              <b-badge
+                pill variant="primary"
+                class="mr-1 mb-1"
+                v-for="tag in node.tags"
+                :key="tag"
+              >
+                {{ tag }}
+              </b-badge>
+            </b-card-text>
+          </template>
+        </b-card>
+      </template>
+    </b-carousel-slide>
   </ContentLink>
 </template>
 
 <script>
+import VClamp from 'vue-clamp';
 import { mapState } from 'vuex';
 import cardMixin from '@/components/mixins/cardMixin';
 
 export default {
   props: ['node'],
   mixins: [cardMixin],
+  components: {
+    VClamp,
+  },
   computed: {
     ...mapState(['nodes']),
     section() {
       return this.nodes.find((n) => n.id === this.node.parent);
     },
+    backgroundStyle() {
+      return {
+        backgroundImage: `url("${this.thumbnail}")`,
+      };
+    },
   },
 };
 </script>
+
+<style lang="scss" scoped>
+@import '@/styles.scss';
+
+.badge {
+  font-size: $font-size-base;
+}
+.card {
+  border-radius: $border-radius-lg;
+  padding-left: 50%;
+  position: relative;
+  min-height: $carousel-min-height;
+}
+.img {
+  border-top-left-radius: $border-radius-lg;
+  border-bottom-left-radius: $border-radius-lg;
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  top: 0;
+  width: 50%;
+  background-repeat: no-repeat;
+  background-size: cover;
+  background-position: left center;
+}
+</style>

--- a/template-ui/src/styles.scss
+++ b/template-ui/src/styles.scss
@@ -1,6 +1,7 @@
 $primary: #F15A22;
 
 $border-radius-lg: 1rem;
+$carousel-min-height: 300px;
 
 @import '@/overrides/styles.scss';
 @import '../node_modules/bootstrap/scss/bootstrap';


### PR DESCRIPTION
This patch modifies the CarouselCard template to show the thumbnail to
the left and the description to the right.

This can't be done with a simple <b-card img-left> because that will
draw the image with it's size and not every thumbnails has the same
size, so to be able to adapt the thumbnail to the half of the card we
need to use the cover css property and the thumbnail as background.

https://phabricator.endlessm.com/T31719