### PR TITLE
template: Improve header icon and lead responsiveness

### DIFF
--- a/template-ui/src/components/Header.vue
+++ b/template-ui/src/components/Header.vue
@@ -1,16 +1,24 @@
 <template>
-  <b-jumbotron fluid :lead="headerDescription"
+  <b-jumbotron fluid
     :style="{ backgroundImage: headerImageURL }"
   >
     <template v-slot:header>
       <div class="d-flex justify-content-between align-items-start">
       <div>{{ section.title }}</div>
       <b-img
+        class="rounded-lg"
+        :width="headerLogoWidth"
         v-if="displayLogoInHeader && channel.thumbnail"
         :src="channel.thumbnail"
-        :alt="channel.title"
       />
       </div>
+    </template>
+    <template v-slot:lead>
+      <b-row>
+        <b-col md="6" sm="12">
+          <div>{{ headerDescription }}</div>
+        </b-col>
+      </b-row>
     </template>
     <HeaderSearchBar />
   </b-jumbotron>
@@ -18,8 +26,14 @@
 
 <script>
 import { mapState, mapGetters } from 'vuex';
+import { headerLogoWidth } from '@/styles.scss';
 
 export default {
+  data() {
+    return {
+      headerLogoWidth,
+    };
+  },
   computed: {
     ...mapState(['channel', 'section', 'displayLogoInHeader']),
     ...mapGetters(['headerDescription', 'getAssetURL']),
@@ -38,12 +52,4 @@ export default {
   background-size: cover;
 }
 
-@include media-breakpoint-up(lg) {
-  .lead {
-    width: 50%;
-  }
-  .img {
-    width: $header-logo-width;
-  }
-}
 </style>

--- a/template-ui/src/styles.scss
+++ b/template-ui/src/styles.scss
@@ -4,7 +4,11 @@ $border-radius-lg: 1rem;
 
 // Template variables:
 $carousel-min-height: 300px;
-$header-logo-width: 128px;
+$header-logo-width: 128;
+
+:export {
+  headerLogoWidth: $header-logo-width;
+}
 
 @import '@/overrides/styles.scss';
 @import '../node_modules/bootstrap/scss/bootstrap';


### PR DESCRIPTION
The `<b-img>` component expects the width in the template, not in the
CSS. So export the variable in the SCSS and import it in the
component, so we can use it in the template part.

Use the grid system for automatically adjusting the lead, instead of
using the CSS breakpoints.

Also, make the icon rounded as in latest design.

https://phabricator.endlessm.com/T31767