### PR TITLE
Template: Fixed CardBody size

### DIFF
--- a/template-ui/src/components/CardBody.vue
+++ b/template-ui/src/components/CardBody.vue
@@ -1,6 +1,6 @@
 <template>
-  <div>
-    <p class="text-uppercase text-info mb-1">
+  <div class="card-content">
+    <p class="text-uppercase text-info mb-1 text-truncate">
       <span v-if="typeTag">{{ typeTag }}</span>
       <span v-if="typeTag && gradeOrLevelTag"> • </span>
       <span v-if="gradeOrLevelTag">{{ gradeOrLevelTag }}</span>
@@ -13,7 +13,9 @@
         {{ node.title }}
       </v-clamp>
     </h5>
-    <p class="text-muted mb-1">{{ getCardSubtitle(node) }}</p>
+    <p class="text-muted mb-1 text-truncate">
+      {{ getCardSubtitle(node) }}
+    </p>
     <b-badge
       pill variant="primary"
       class="mr-1 mb-1"
@@ -56,3 +58,23 @@ export default {
   },
 };
 </script>
+
+<style lang="scss" scoped>
+@import '@/styles.scss';
+
+$type-line-height: $font-size-base * $line-height-base;
+$title-line-height: 3 * ($h5-font-size * $headings-line-height);
+$subtitle-line-height: $font-size-base * $line-height-base;
+$tags-line-height: $font-size-base * $line-height-base;
+
+$margins: map-get($spacers, 1) * 4;
+
+$total-card-height: ($type-line-height + $title-line-height +
+                     $subtitle-line-height + $tags-line-height +
+                     $margins);
+
+.card-content {
+  min-height: $total-card-height;
+}
+
+</style>

--- a/template-ui/src/components/CardBody.vue
+++ b/template-ui/src/components/CardBody.vue
@@ -5,7 +5,7 @@
       <span v-if="typeTag && gradeOrLevelTag"> • </span>
       <span v-if="gradeOrLevelTag">{{ gradeOrLevelTag }}</span>
     </p>
-    <h5 class="mb-1">
+    <h5 class="title mb-1">
       <v-clamp
         autoresize
         :max-lines="3"
@@ -13,17 +13,19 @@
         {{ node.title }}
       </v-clamp>
     </h5>
-    <p class="text-muted mb-1 text-truncate">
+    <p class="subtitle text-muted mb-1 text-truncate">
       {{ getCardSubtitle(node) }}
     </p>
-    <b-badge
-      pill variant="primary"
-      class="mr-1 mb-1"
-      v-for="tag in subjectTags"
-      :key="tag"
-    >
-      {{ tag }}
-    </b-badge>
+    <div class="tags">
+      <b-badge
+        pill variant="primary"
+        class="mr-1 mb-1"
+        v-for="tag in subjectTags"
+        :key="tag"
+      >
+        {{ tag }}
+      </b-badge>
+    </div>
   </div>
 </template>
 
@@ -75,6 +77,13 @@ $total-card-height: ($type-line-height + $title-line-height +
 
 .card-content {
   min-height: $total-card-height;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+.subtitle {
+  flex-grow: 3;
 }
 
 </style>


### PR DESCRIPTION
This patch sets the minimum size for cards to a fixed number that's
caculated with the max size that can have with all the content:

 * Type + Level (1 line)
 * Title (up to 3 lines <h5>)
 * Subtitle (1 line)
 * Tags (1 line)

https://phabricator.endlessm.com/T31870