### PR TITLE
Template: Add unorm polyfill

### DIFF
--- a/template-ui/package.json
+++ b/template-ui/package.json
@@ -18,6 +18,7 @@
     "kolibri-api": "0.1.0",
     "slugify": "^1.4.5",
     "underscore": "^1.11.0",
+    "unorm": "^1.6.0",
     "vue": "^2.6.11",
     "vue-clamp": "^0.3.1",
     "vue-router": "^3.2.0",

--- a/template-ui/src/utils.js
+++ b/template-ui/src/utils.js
@@ -1,3 +1,7 @@
+// Import unorm to add normalize polyfill, to make it work on IE11, needed by
+// slugify.
+import 'unorm';
+
 import slugify from 'slugify';
 import arrayToTree from 'array-to-tree';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8500,6 +8500,11 @@ universalify@^0.1.0:
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
 
+unorm@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/unorm/-/unorm-1.6.0.tgz#029b289661fba714f1a9af439eb51d9b16c205af"
+  integrity sha512-b2/KCUlYZUeA7JFUuRJZPUtr4gZvBh7tavtv4fvk4+KV9pfGiR6CQAQAWl49ZpR3ts2dk4FYkP7EIgDJoiOLDA==
+
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"


### PR DESCRIPTION
The slugify library uses String.normalize, that's not supported on old
browsers like IE11 and there's no polyfill for this on babel/core-js.

This patch includes the unorm library, that implements the
String.normalize and could be used as polyfill for this feature to work
on IE11.

You can find more information here:
 * https://github.com/sindresorhus/slugify/issues/32
 * https://github.com/zloirock/core-js#missing-polyfills
 * https://stackoverflow.com/a/54242857

https://phabricator.endlessm.com/T31929