### PR TITLE
template: Improve style in header

### DIFF
--- a/template-ui/src/components/Header.vue
+++ b/template-ui/src/components/Header.vue
@@ -16,7 +16,7 @@
       </div>
       <b-row>
         <b-col md="6" sm="12">
-          <div class="lead mb-2">{{ headerDescription }}</div>
+          <div class="lead text-muted mb-2">{{ headerDescription }}</div>
         </b-col>
       </b-row>
     </template>
@@ -63,9 +63,17 @@ export default {
 <style lang="scss" scoped>
 @import '@/styles.scss';
 
+// FIXME this will be the secondary color instead of a custom color derived from the success color.
+// Waiting for the change in Figma.
+$header-color: rgba($success, 0.5);
+
 .jumbotron {
-  background-color: $body-bg;
+  background-color: $header-color;
   background-size: cover;
+}
+
+img {
+  box-shadow: $toast-box-shadow;
 }
 
 </style>


### PR DESCRIPTION
- Set header background color to green (success at 50% alpha)
- Set header description color to "muted"
- Add box shadow to channel brand / icon asset

Also, add a FIXME comment for updating the background color.

https://phabricator.endlessm.com/T31960