### PR TITLE
Template: Fix footer positioning on IE11

### DIFF
--- a/template-ui/src/App.vue
+++ b/template-ui/src/App.vue
@@ -1,8 +1,11 @@
 <template>
   <div id="app" class="d-flex flex-column h-100">
-    <router-view>
-      <Header />
-    </router-view>
+    <!-- Wrapper needed to fix flexbox footer positioning on IE11 -->
+    <div class="flex-shrink-0">
+      <router-view>
+        <Header />
+      </router-view>
+    </div>
     <Footer />
   </div>
 </template>


### PR DESCRIPTION
This patch adds a wrapper div class to set the flex-shrink to 0 to fix
the flex positioning of the footer on IE11.

More info here: https://stackoverflow.com/a/49368815

https://phabricator.endlessm.com/T31967